### PR TITLE
fix(add): prevent pando add from leaving new worktrees dirty

### DIFF
--- a/.pando.toml.example
+++ b/.pando.toml.example
@@ -38,6 +38,15 @@ exclude = [
   "tmp/",
 ]
 
+# Sync only gitignored artifacts (.venv, node_modules, build caches)
+# true (default): only files git ignores are copied. Tracked files come from
+#   git checkout, so nothing tracked can be clobbered - safe for any branch,
+#   including existing branches on different commits.
+# false: mirror the full source tree. Runs only when source and target are on
+#   the same commit (a guard against copying tracked files across branches);
+#   carries uncommitted tracked changes from the source worktree.
+onlyUntracked = true
+
 # ============================================================================
 # Symlink Configuration
 # ============================================================================
@@ -75,6 +84,16 @@ relative = true
 # After: Rsync copies files, then they're replaced with symlinks
 # Default: true (before rsync)
 beforeRsync = true
+
+# Allow symlinking paths that are git-tracked in the new worktree
+# A tracked path replaced by a symlink (package.json, lockfiles) would show as
+# deleted/modified in git status, so pando hides it via skip-worktree. That is
+# local per-clone state git can silently drop - the post-setup clean-tree
+# check surfaces any drift.
+# true (default): tracked patterns are symlinked and marked skip-worktree
+# false (strict): tracked patterns are skipped with a warning; only
+#   gitignored paths get symlinked
+allowTracked = true
 
 # ============================================================================
 # Worktree Configuration
@@ -187,9 +206,11 @@ deleteBranchOnRemove = "local"
 #   PANDO_RSYNC_ENABLED=false
 #   PANDO_RSYNC_FLAGS=--archive
 #   PANDO_RSYNC_EXCLUDE=*.log,tmp/
+#   PANDO_RSYNC_ONLY_UNTRACKED=false
 #   PANDO_SYMLINK_PATTERNS=package.json,pnpm-lock.yaml
 #   PANDO_SYMLINK_RELATIVE=false
 #   PANDO_SYMLINK_BEFORE_RSYNC=true
+#   PANDO_SYMLINK_ALLOW_TRACKED=true
 #   PANDO_WORKTREE_DEFAULT_PATH=../worktrees
 #   PANDO_WORKTREE_REBASE_ON_ADD=false
 #   PANDO_WORKTREE_DELETE_BRANCH_ON_REMOVE=local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`rsync.onlyUntracked`** config option (env: `PANDO_RSYNC_ONLY_UNTRACKED`,
+  default `true`) — rsync now syncs only files that are gitignored in the
+  source worktree (build artifacts like `.venv/`, `node_modules/`, caches) via
+  `--files-from`. Tracked files always come from the new worktree's own
+  checkout, so rsync can never dirty the tree, and artifact syncing now works
+  for existing branches on different commits (previously skipped entirely).
+  Set to `false` for the legacy full-tree mirror, which still only runs when
+  source and target share the same commit.
+- **`symlink.allowTracked`** config option (env: `PANDO_SYMLINK_ALLOW_TRACKED`,
+  default `true`) — set to `false` for strict mode: symlink patterns matching
+  git-tracked paths are skipped with a warning so only gitignored paths get
+  symlinked.
+- **Clean-tree check** — after setup, `pando add` runs `git status` in the new
+  worktree and warns (with the offending paths) if anything unexpected shows
+  up; `--json` output includes `setup.cleanTree` for automation.
+
 - **`pando health`** — new command that reports the status of every worktree
   (`clean`, `uncommitted`, `behind`, `gone`, `detached`, `error`) with a summary
   and `--json` output.
@@ -44,6 +60,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`pando add` no longer leaves the new worktree dirty.** Marking symlinked
+  files as skip-worktree previously aborted the entire batch when any symlink
+  pattern matched an untracked/gitignored path (e.g. `.env`), leaving every
+  tracked symlink (e.g. `CLAUDE.md`, `.claude/`) visible as deleted or
+  type-changed (`filesMarked: 0, success: false`). `setSkipWorktree` now
+  filters to git-tracked paths, expands symlinked directories to their tracked
+  entries (a directory itself cannot be marked), marks in chunks with a
+  per-file fallback, and reports accurate `filesMarked`/`success` values.
+- rsync can no longer copy the source branch's tracked files over a different
+  branch's checkout (modified tracked files + untracked spillover) — see
+  `rsync.onlyUntracked` above.
 - **`pando health`** behind-upstream detection now counts commits in the correct
   direction, surfaces remote-check failures as `error` instead of silently
   reporting `clean`, and reports detached-HEAD worktrees as `detached`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,14 +185,19 @@ if (flags['skip-rsync'] && (flags['rsync-flags'] || flags['rsync-exclude'])) {
 
 ### Rsync/Symlink Coordination
 ```typescript
-// CRITICAL: Match symlink patterns BEFORE rsync to exclude them
-if (!options.skipSymlink && symlinkConfig.patterns.length > 0) {
-  const filesToSymlink = await this.symlinkHelper.matchPatterns(sourceTreePath, symlinkConfig.patterns)
-  excludePatterns.push(...filesToSymlink)
-}
-rsyncResult = await this.rsyncHelper.rsync(source, dest, config, { excludePatterns })
+// CRITICAL: The symlink plan (matched items, minus tracked paths in strict
+// mode) is computed ONCE up front and consumed by every phase, so the symlink
+// phases, rsync exclusions, and clean-tree check all agree on what is symlinked
+const symlinkItems = /* matchPatterns + allowTracked filtering */
+excludePatterns.push(...symlinkItems.map(formatAsAnchoredPattern))
+// Default rsync is untracked-only: sync exactly the source's gitignored files
+const filesFrom = await this.gitHelper.listIgnoredFiles(sourceTreePath)
+rsyncResult = await this.rsyncHelper.rsync(source, dest, config, { excludePatterns, filesFrom })
 ```
-**Location**: `src/utils/worktreeSetup.ts` (Phase 4)
+**Location**: `src/utils/worktreeSetup.ts` (Phase 1 plan, Phase 4 rsync)
+**Invariant**: after setup, `git status` in the new worktree is empty aside from
+pando-created symlinks (`SetupResult.cleanTree`); tracked files are NEVER
+copied by rsync (tracked symlinks are hidden via skip-worktree instead)
 
 ### Transactional Rollback
 ```typescript

--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ Create a new git worktree (supports both creating new branches and checking out 
 
 **Automatic Rebase**: When checking out an existing branch, pando automatically rebases it onto the current branch. This keeps your feature branches up-to-date. If the rebase fails (e.g., conflicts), a warning is shown but the worktree is still created. Use `--no-rebase` to skip this behavior, or set `worktree.rebaseOnAdd = false` in config.
 
-**Rsync Behavior**: Rsync runs only when it is safe for the new worktree's checkout. If the source worktree is on a different commit than the newly created worktree (for example, `--commit main` while the source checkout is on a feature branch), pando skips rsync and reports a warning so tracked files from the source branch do not dirty the new checkout. Use `--skip-rsync` to disable rsync explicitly.
+**Rsync Behavior**: By default (`rsync.onlyUntracked = true`), rsync carries over only files that git ignores in the source worktree — build artifacts like `.venv/`, `node_modules/`, and caches. Tracked files always come from the new worktree's own checkout, so rsync can never dirty the tree, and artifact syncing works even when the new worktree is on a different branch or commit. Non-ignored untracked files (work in progress) are deliberately not copied. With `rsync.onlyUntracked = false`, pando mirrors the full source tree instead, but only when the source and new worktree are on the same commit — otherwise rsync is skipped with a warning so tracked files from the source branch do not dirty the new checkout. Use `--skip-rsync` to disable rsync explicitly.
+
+**Clean-tree check**: After setup, pando runs `git status` in the new worktree. If anything unexpected shows up (beyond the symlinks pando itself created), a warning lists the offending paths, and JSON output reports `setup.cleanTree: false` so automation can detect it.
+
+**Symlinking tracked paths**: When a symlink pattern matches a git-tracked path (`package.json`, a lockfile), replacing the checked-out file with a symlink would make `git status` report deletions/modifications — so pando hides those entries via `git update-index --skip-worktree`. Untracked/gitignored patterns need no hiding and are filtered from the skip-worktree step automatically. Skip-worktree is local, per-clone state that git can silently drop; the clean-tree check surfaces any drift. Set `symlink.allowTracked = false` for strict mode: tracked patterns are then skipped with a warning, and only gitignored paths get symlinked.
 
 **Examples:**
 
@@ -508,12 +512,16 @@ Pando uses TOML format for configuration:
 enabled = true
 flags = ["--archive"]         # .git is always excluded automatically (do not add it here)
 exclude = ["dist/", "node_modules/"]
+onlyUntracked = true          # Sync only gitignored artifacts (default). false = mirror the
+                              # full tree, but only when source/target share the same commit.
 
 # Symlink Configuration
 [symlink]
 patterns = ["package.json", ".env*"]
 relative = true
 beforeRsync = true
+allowTracked = true           # Symlink git-tracked paths, hidden via skip-worktree (default).
+                              # false = strict mode: skip tracked patterns with a warning.
 
 # Worktree Configuration
 [worktree]
@@ -674,9 +682,11 @@ Environment variables override file-based configuration but are overridden by ex
 | `PANDO_RSYNC_ENABLED`                    | `rsync.enabled`                | boolean |
 | `PANDO_RSYNC_FLAGS`                      | `rsync.flags`                  | array   |
 | `PANDO_RSYNC_EXCLUDE`                    | `rsync.exclude`                | array   |
+| `PANDO_RSYNC_ONLY_UNTRACKED`             | `rsync.onlyUntracked`          | boolean |
 | `PANDO_SYMLINK_PATTERNS`                 | `symlink.patterns`             | array   |
 | `PANDO_SYMLINK_RELATIVE`                 | `symlink.relative`             | boolean |
 | `PANDO_SYMLINK_BEFORE_RSYNC`             | `symlink.beforeRsync`          | boolean |
+| `PANDO_SYMLINK_ALLOW_TRACKED`            | `symlink.allowTracked`         | boolean |
 | `PANDO_WORKTREE_DEFAULT_PATH`            | `worktree.defaultPath`         | string  |
 | `PANDO_WORKTREE_REBASE_ON_ADD`           | `worktree.rebaseOnAdd`         | boolean |
 | `PANDO_WORKTREE_DELETE_BRANCH_ON_REMOVE` | `worktree.deleteBranchOnRemove`| string  |

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "chalk": "^5.6.2",
     "fs-extra": "^11.3.2",
     "globby": "^14.1.0",
+    "micromatch": "^4.0.8",
     "ora": "^8.2.0",
     "simple-git": "^3.30.0",
     "zod": "^4.4.3"
@@ -101,6 +102,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
+    "@types/micromatch": "^4.0.10",
     "@types/node": "^25.9.2",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       globby:
         specifier: ^14.1.0
         version: 14.1.0
+      micromatch:
+        specifier: ^4.0.8
+        version: 4.0.8
       ora:
         specifier: ^8.2.0
         version: 8.2.0
@@ -39,6 +42,9 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
+      '@types/micromatch':
+        specifier: ^4.0.10
+        version: 4.0.10
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -1246,6 +1252,9 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@types/braces@3.0.5':
+    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
+
   '@types/docker-modem@3.0.6':
     resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
 
@@ -1266,6 +1275,9 @@ packages:
 
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
+
+  '@types/micromatch@4.0.10':
+    resolution: {integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==}
 
   '@types/mute-stream@0.0.4':
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
@@ -4508,6 +4520,8 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
+  '@types/braces@3.0.5': {}
+
   '@types/docker-modem@3.0.6':
     dependencies:
       '@types/node': 25.9.2
@@ -4533,6 +4547,10 @@ snapshots:
   '@types/jsonfile@6.1.4':
     dependencies:
       '@types/node': 25.9.2
+
+  '@types/micromatch@4.0.10':
+    dependencies:
+      '@types/braces': 3.0.5
 
   '@types/mute-stream@0.0.4':
     dependencies:

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -818,6 +818,9 @@ export default class AddWorktree extends Command {
                     success: setupResult.skipWorktreeResult.success,
                   }
                 : null,
+              // null = the status check could not run; automation should treat
+              // false as "worktree needs inspection" (details in warnings)
+              cleanTree: setupResult.cleanTree ?? null,
             },
             postCommands: postCommandResults,
             duration,
@@ -937,6 +940,11 @@ export default class AddWorktree extends Command {
         } else {
           output.push(chalk.gray('  Symlinks: not run'))
         }
+      }
+
+      // Clean-tree check (details are in the warnings section)
+      if (setupResult.cleanTree === false) {
+        output.push(chalk.yellow('⚠ git status is not clean in the new worktree'))
       }
 
       // Warnings

--- a/src/commands/config/init.ts
+++ b/src/commands/config/init.ts
@@ -301,6 +301,12 @@ export default class ConfigInit extends Command {
       } else {
         added.push({ path: 'rsync.exclude', value: DEFAULT_CONFIG.rsync.exclude })
       }
+
+      if (existing.rsync.onlyUntracked !== undefined) {
+        merged.rsync.onlyUntracked = existing.rsync.onlyUntracked
+      } else {
+        added.push({ path: 'rsync.onlyUntracked', value: DEFAULT_CONFIG.rsync.onlyUntracked })
+      }
     } else {
       added.push({ path: 'rsync', value: DEFAULT_CONFIG.rsync })
     }
@@ -323,6 +329,12 @@ export default class ConfigInit extends Command {
         merged.symlink.beforeRsync = existing.symlink.beforeRsync
       } else {
         added.push({ path: 'symlink.beforeRsync', value: DEFAULT_CONFIG.symlink.beforeRsync })
+      }
+
+      if (existing.symlink.allowTracked !== undefined) {
+        merged.symlink.allowTracked = existing.symlink.allowTracked
+      } else {
+        added.push({ path: 'symlink.allowTracked', value: DEFAULT_CONFIG.symlink.allowTracked })
       }
     } else {
       added.push({ path: 'symlink', value: DEFAULT_CONFIG.symlink })
@@ -410,6 +422,9 @@ export default class ConfigInit extends Command {
     const sections = [
       '# Rsync Configuration',
       '# Controls how files are copied from source tree to new worktrees',
+      '# onlyUntracked - Sync only gitignored artifacts (.venv, node_modules, caches)',
+      '#   true (default): safe for any branch; tracked files are never copied',
+      '#   false: mirror the full source tree (only when both are on the same commit)',
       '',
     ].join('\n')
 
@@ -418,6 +433,8 @@ export default class ConfigInit extends Command {
       '# Symlink Configuration',
       '# Controls which files are symlinked instead of copied',
       '# Patterns support glob syntax (e.g., "*.json", ".env*")',
+      '# allowTracked - Allow symlinking git-tracked paths (hidden via skip-worktree)',
+      '#   true (default); false = strict mode: tracked patterns are skipped with a warning',
       '',
     ].join('\n')
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -29,11 +29,13 @@ const ENV_VAR_MAP: Record<string, string> = {
   PANDO_RSYNC_ENABLED: 'rsync.enabled',
   PANDO_RSYNC_FLAGS: 'rsync.flags',
   PANDO_RSYNC_EXCLUDE: 'rsync.exclude',
+  PANDO_RSYNC_ONLY_UNTRACKED: 'rsync.onlyUntracked',
 
   // Symlink settings
   PANDO_SYMLINK_PATTERNS: 'symlink.patterns',
   PANDO_SYMLINK_RELATIVE: 'symlink.relative',
   PANDO_SYMLINK_BEFORE_RSYNC: 'symlink.beforeRsync',
+  PANDO_SYMLINK_ALLOW_TRACKED: 'symlink.allowTracked',
 
   // Worktree settings
   PANDO_WORKTREE_DEFAULT_PATH: 'worktree.defaultPath',
@@ -117,13 +119,14 @@ export function parseEnvValue(key: string, value: string): unknown {
     return parseArray(value)
   }
 
-  // Boolean fields
+  // Boolean fields ('TRACKED' covers ONLY_UNTRACKED and ALLOW_TRACKED)
   if (
     key.includes('ENABLED') ||
     key.includes('RELATIVE') ||
     key.includes('BEFORE') ||
     key.includes('REBASE') ||
     key.includes('USE_') ||
+    key.includes('TRACKED') ||
     key.endsWith('_FETCH')
   ) {
     return parseBoolean(value)

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -21,6 +21,7 @@ export const RsyncConfigSchema = z.object({
   // so it must NOT be duplicated in the default flags.
   flags: z.array(z.string()).default(['--archive']),
   exclude: z.array(z.string()).default([]),
+  onlyUntracked: z.boolean().default(true),
 })
 
 /**
@@ -30,6 +31,7 @@ export const RsyncConfigSchemaPartial = z.object({
   enabled: z.boolean().optional(),
   flags: z.array(z.string()).optional(),
   exclude: z.array(z.string()).optional(),
+  onlyUntracked: z.boolean().optional(),
 })
 
 /**
@@ -39,6 +41,7 @@ export const SymlinkConfigSchema = z.object({
   patterns: z.array(z.string()).default([]),
   relative: z.boolean().default(true),
   beforeRsync: z.boolean().default(true),
+  allowTracked: z.boolean().default(true),
 })
 
 /**
@@ -48,6 +51,7 @@ export const SymlinkConfigSchemaPartial = z.object({
   patterns: z.array(z.string()).optional(),
   relative: z.boolean().optional(),
   beforeRsync: z.boolean().optional(),
+  allowTracked: z.boolean().optional(),
 })
 
 /**
@@ -162,6 +166,16 @@ export interface RsyncConfig {
    * @example ['*.log', 'tmp/', 'node_modules/']
    */
   exclude: string[]
+
+  /**
+   * Only sync files that are untracked in the source worktree (build artifacts,
+   * virtualenvs, caches). Tracked files come from git checkout, so copying them
+   * would dirty the new worktree whenever branches differ. When false, the full
+   * source tree is mirrored - but only when source and target are on the same
+   * commit (a safety guard against cross-branch clobbering).
+   * @default true
+   */
+  onlyUntracked?: boolean
 }
 
 /**
@@ -188,6 +202,18 @@ export interface SymlinkConfig {
    * @default true
    */
   beforeRsync: boolean
+
+  /**
+   * Allow symlinking paths that are git-tracked in the new worktree
+   * (lockfiles, package.json). Tracked-path symlinks would show as
+   * deleted/type-changed in git status, so pando hides them via
+   * skip-worktree - local, per-clone state that git can silently drop; the
+   * post-setup clean-tree check catches any drift. Set to false to skip
+   * tracked patterns with a warning instead (strict mode: symlink only
+   * gitignored paths).
+   * @default true
+   */
+  allowTracked?: boolean
 }
 
 /**
@@ -392,11 +418,13 @@ export const DEFAULT_CONFIG: PandoConfig = {
     // `.git` is excluded programmatically in fileOps.buildArgs (non-configurable).
     flags: ['--archive'],
     exclude: [],
+    onlyUntracked: true,
   },
   symlink: {
     patterns: [],
     relative: true,
     beforeRsync: true,
+    allowTracked: true,
   },
   worktree: {
     rebaseOnAdd: true,

--- a/src/utils/DESIGN.md
+++ b/src/utils/DESIGN.md
@@ -51,6 +51,47 @@ const result = await transaction.rollback()
 
 **Trade-off**: Requires rsync to be installed
 
+### Untracked-Only Sync (Clean-Tree Invariant)
+**Chosen**: By default, rsync transfers only files that are gitignored in the
+source worktree (`git ls-files --others --ignored --exclude-standard`), passed
+via `--files-from`/`--from0`.
+**Rationale**:
+- Tracked files come from the target's own `git checkout`; copying them from
+  the source clobbers the target whenever the branches differ (the "dirty
+  worktree" bug)
+- Gitignored artifacts (.venv, node_modules, caches) are exactly the
+  expensive-to-rebuild files worth carrying over, and they never appear in
+  `git status`
+- Non-ignored untracked files (WIP) are deliberately left behind so the new
+  worktree starts clean
+- Safe across commits, so existing-branch worktrees still get artifact sync
+
+The exclude patterns are ALSO applied to the file list in JS
+(`RsyncHelper.filterExcludedPaths`, micromatch-based) because rsync
+implementations disagree on whether filter rules apply to `--files-from`
+entries (openrsync does not apply directory excludes to listed files).
+
+`rsync.onlyUntracked = false` restores the legacy full-tree mirror, which only
+runs when source and target are on the same commit.
+
+After setup, the orchestrator verifies the invariant: `git status` in the new
+worktree must be empty aside from the symlinks pando itself created
+(`SetupResult.cleanTree`, surfaced as `setup.cleanTree` in `pando add --json`).
+
+### Skip-Worktree for Tracked Symlinks
+**Chosen**: `GitHelper.setSkipWorktree` intersects requested paths with
+`git ls-files` before marking, expanding directories to their tracked entries.
+**Rationale**:
+- `git update-index --skip-worktree` dies on any path not in the index, so a
+  single untracked path (a gitignored `.env` symlink) used to abort the whole
+  batch and leave every tracked symlink visible as deleted/modified
+- Untracked/ignored symlinks never show in status and need no marking
+- Directories cannot be marked; their tracked contents can
+- Failed batches retry per file so one bad path cannot hide the rest
+
+`symlink.allowTracked = false` (strict mode) skips tracked patterns entirely
+with a warning instead of symlinking + hiding them.
+
 ### Separate Concerns
 **Chosen**: Separate helpers for rsync, symlink, and orchestration
 **Rationale**:

--- a/src/utils/fileOps.ts
+++ b/src/utils/fileOps.ts
@@ -3,6 +3,7 @@ import { symlink as fsSymlink, readlink as fsReadlink, lstat as fsLstat } from '
 import { exec, spawn } from 'child_process'
 import { promisify } from 'util'
 import { globby } from 'globby'
+import micromatch from 'micromatch'
 import * as path from 'path'
 import * as os from 'os'
 import type { RsyncConfig, SymlinkConfig } from '../config/schema.js'
@@ -557,6 +558,45 @@ export class RsyncHelper {
   }
 
   /**
+   * Filter a list of relative paths against rsync-style exclude patterns.
+   *
+   * Interprets the common rsync pattern forms: a trailing `/` means "directory
+   * and everything under it", a leading `/` anchors to the transfer root, and
+   * an unanchored pattern matches at any depth. Full rsync filter grammar
+   * (`+`/`-` rules, negations) is out of scope - those still reach rsync
+   * itself via --exclude.
+   *
+   * @param files - Relative paths to filter
+   * @param patterns - rsync-style exclude patterns
+   * @returns Paths not matched by any pattern
+   */
+  static filterExcludedPaths(files: string[], patterns: string[]): string[] {
+    const globs: string[] = []
+    for (const rawPattern of patterns) {
+      let pattern = rawPattern.trim()
+      if (!pattern) continue
+      // Trailing slash: rsync dir-only semantics; the glob expansions below
+      // already cover the directory's contents
+      pattern = pattern.replace(/\/+$/, '')
+
+      if (pattern.startsWith('/')) {
+        // Anchored to the transfer root
+        const base = pattern.slice(1)
+        globs.push(base, `${base}/**`)
+      } else {
+        // Unanchored: matches at any depth
+        globs.push(pattern, `${pattern}/**`, `**/${pattern}`, `**/${pattern}/**`)
+      }
+    }
+
+    if (globs.length === 0) {
+      return files
+    }
+
+    return files.filter((file) => !micromatch.isMatch(file, globs, { dot: true }))
+  }
+
+  /**
    * Execute rsync from source to destination
    *
    * @param source - Source directory
@@ -566,6 +606,9 @@ export class RsyncHelper {
    * @param options.excludePatterns - Additional patterns to exclude
    * @param options.totalFiles - Pre-estimated file count for progress percentage
    * @param options.onProgress - Callback for real-time progress updates
+   * @param options.filesFrom - Restrict the transfer to exactly these relative
+   *   paths (via rsync --files-from). An empty array is a successful no-op.
+   *   Exclude patterns still apply on top of the list.
    */
   async rsync(
     source: string,
@@ -575,8 +618,24 @@ export class RsyncHelper {
       excludePatterns?: string[]
       totalFiles?: number
       onProgress?: RsyncProgressCallback
+      filesFrom?: string[]
     } = {}
   ): Promise<RsyncResult> {
+    // rsync implementations disagree on whether filter rules apply to
+    // --files-from entries (openrsync does not apply directory excludes to
+    // explicitly listed files), so the exclusion is enforced here on the list
+    // itself. The --exclude args are still passed as a second layer.
+    let filesFrom = options.filesFrom
+    if (filesFrom && filesFrom.length > 0) {
+      const allExcludes = [...(config.exclude || []), ...(options.excludePatterns || []), '.git']
+      filesFrom = RsyncHelper.filterExcludedPaths(filesFrom, allExcludes)
+    }
+
+    // Nothing to transfer: skip the spawn entirely and record no operation
+    if (filesFrom && filesFrom.length === 0) {
+      return { success: true, filesTransferred: 0, bytesSent: 0, totalSize: 0, duration: 0 }
+    }
+
     // Check if rsync is installed and get version info
     const versionInfo = await this.getVersionInfo()
     if (!versionInfo.installed) {
@@ -593,6 +652,18 @@ export class RsyncHelper {
       internalFlags.push('--progress')
     }
 
+    // File names can contain any character except NUL, so the list is written
+    // NUL-separated (--from0) to a temp file rather than passed as argv.
+    let filesFromPath: string | undefined
+    if (filesFrom) {
+      filesFromPath = path.join(
+        os.tmpdir(),
+        `pando-files-from-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      )
+      await fs.writeFile(filesFromPath, filesFrom.join('\0') + '\0')
+      internalFlags.push(`--files-from=${filesFromPath}`, '--from0')
+    }
+
     // Build args array for spawn
     // Pass internal flags separately so they aren't filtered by sanitizeFlags
     const args = this.buildArgs(
@@ -605,6 +676,12 @@ export class RsyncHelper {
 
     // Record start time
     const startTime = Date.now()
+
+    const cleanupFilesFrom = async (): Promise<void> => {
+      if (filesFromPath) {
+        await fs.remove(filesFromPath).catch(() => {})
+      }
+    }
 
     return new Promise((resolve, reject) => {
       const rsyncProcess = spawn('rsync', args)
@@ -662,6 +739,8 @@ export class RsyncHelper {
       })
 
       rsyncProcess.on('close', (code) => {
+        void cleanupFilesFrom()
+
         // Send final progress update (in case last update was throttled)
         if (options.onProgress && filesTransferred > 0) {
           const totalFiles = options.totalFiles || 0
@@ -691,6 +770,7 @@ export class RsyncHelper {
       })
 
       rsyncProcess.on('error', (error) => {
+        void cleanupFilesFrom()
         reject(new FileOperationError(`rsync failed: ${error.message}`, error))
       })
     })
@@ -1099,6 +1179,10 @@ export class SymlinkHelper {
 
   /**
    * Create multiple symlinks from patterns
+   *
+   * @param options.items - Precomputed relative paths to symlink, bypassing
+   *   pattern matching. Lets callers filter matches (e.g. drop git-tracked
+   *   paths) without literal file names being re-interpreted as globs.
    */
   async createSymlinks(
     sourceDir: string,
@@ -1107,6 +1191,7 @@ export class SymlinkHelper {
     options: {
       replaceExisting?: boolean
       skipConflicts?: boolean
+      items?: string[]
     } = {}
   ): Promise<SymlinkResult> {
     const result: SymlinkResult = {
@@ -1118,7 +1203,7 @@ export class SymlinkHelper {
 
     try {
       // Match files against config.patterns
-      const matches = await this.matchPatterns(sourceDir, config.patterns)
+      const matches = options.items ?? (await this.matchPatterns(sourceDir, config.patterns))
 
       // Build list of (source, target) pairs
       const links: Array<{ source: string; target: string }> = matches.map((relativePath) => ({

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -698,8 +698,15 @@ export class GitHelper {
    * When files are replaced with symlinks, git sees a mode change (100644 -> 120000)
    * and reports them as modified. This method tells git to ignore these changes.
    *
+   * Only paths present in the index can be marked: `git update-index --skip-worktree`
+   * dies on any untracked path (e.g. a gitignored `.env` symlink), which would
+   * otherwise abort the whole batch. Untracked/ignored paths never show in
+   * `git status`, so they are silently filtered out rather than treated as errors.
+   * Directory paths (a symlinked `.claude/`) are expanded to the tracked files
+   * beneath them, since update-index cannot mark a directory.
+   *
    * @param worktreePath - Path to the worktree where files reside
-   * @param files - Array of relative file paths to mark as skip-worktree
+   * @param files - Array of relative file/directory paths to mark as skip-worktree
    * @returns Object with success status, optional error message, and count of files marked
    */
   async setSkipWorktree(
@@ -710,14 +717,118 @@ export class GitHelper {
       return { success: true, filesMarked: 0 }
     }
 
+    const gitInWorktree = simpleGit(worktreePath)
+
+    // `:(literal)` prevents glob interpretation of file names containing *?[]
+    let trackedFiles: string[]
     try {
-      const gitInWorktree = simpleGit(worktreePath)
-      await gitInWorktree.raw(['update-index', '--skip-worktree', ...files])
-      return { success: true, filesMarked: files.length }
+      const pathspecs = files.map((file) => `:(literal)${file}`)
+      const output = await gitInWorktree.raw(['ls-files', '-z', '--', ...pathspecs])
+      trackedFiles = output.split('\0').filter((file) => file.length > 0)
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error)
       return { success: false, error: errorMsg, filesMarked: 0 }
     }
+
+    if (trackedFiles.length === 0) {
+      return { success: true, filesMarked: 0 }
+    }
+
+    let filesMarked = 0
+    const failedFiles: string[] = []
+    // Chunk to stay clear of OS argv limits when a large directory was symlinked
+    const chunkSize = 500
+    for (let i = 0; i < trackedFiles.length; i += chunkSize) {
+      const chunk = trackedFiles.slice(i, i + chunkSize)
+      try {
+        await gitInWorktree.raw(['update-index', '--skip-worktree', ...chunk])
+        filesMarked += chunk.length
+      } catch {
+        // Batch failed - retry per file so one bad path cannot abort the rest
+        for (const file of chunk) {
+          try {
+            await gitInWorktree.raw(['update-index', '--skip-worktree', file])
+            filesMarked++
+          } catch {
+            failedFiles.push(file)
+          }
+        }
+      }
+    }
+
+    if (failedFiles.length > 0) {
+      const shown = failedFiles.slice(0, 5).join(', ')
+      const more = failedFiles.length > 5 ? ` (+${failedFiles.length - 5} more)` : ''
+      return {
+        success: false,
+        error: `Failed to mark ${failedFiles.length} file(s) as skip-worktree: ${shown}${more}`,
+        filesMarked,
+      }
+    }
+
+    return { success: true, filesMarked }
+  }
+
+  /**
+   * List untracked files in a worktree that are gitignored.
+   *
+   * This is the safe rsync set for new worktrees: gitignored artifacts (.venv,
+   * node_modules, build caches) are expensive to rebuild and never show in
+   * `git status`. Tracked files come from git checkout, and non-ignored
+   * untracked files (WIP) are deliberately excluded so the new worktree's
+   * status stays clean.
+   *
+   * @param worktreePath - Path to the worktree to scan
+   * @returns Relative paths of all gitignored untracked files
+   */
+  async listIgnoredFiles(worktreePath: string): Promise<string[]> {
+    const gitInWorktree = simpleGit(worktreePath)
+    const output = await gitInWorktree.raw([
+      'ls-files',
+      '--others',
+      '--ignored',
+      '--exclude-standard',
+      '-z',
+    ])
+    return output.split('\0').filter((file) => file.length > 0)
+  }
+
+  /**
+   * Return the subset of the given relative paths that are git-tracked in the
+   * worktree. A directory counts as tracked when any tracked file lives under it.
+   *
+   * @param worktreePath - Path to the worktree whose index is consulted
+   * @param paths - Relative file or directory paths to check
+   * @returns The tracked subset, in input order
+   */
+  async filterTrackedPaths(worktreePath: string, paths: string[]): Promise<string[]> {
+    if (paths.length === 0) {
+      return []
+    }
+
+    const gitInWorktree = simpleGit(worktreePath)
+    // `:(literal)` prevents glob interpretation of file names containing *?[]
+    const pathspecs = paths.map((p) => `:(literal)${p}`)
+    const output = await gitInWorktree.raw(['ls-files', '-z', '--', ...pathspecs])
+    const trackedEntries = output.split('\0').filter((file) => file.length > 0)
+
+    return paths.filter((p) =>
+      trackedEntries.some((entry) => entry === p || entry.startsWith(`${p}/`))
+    )
+  }
+
+  /**
+   * List paths that show up in `git status` for a worktree (modified, deleted,
+   * type-changed, or untracked). Files marked skip-worktree are hidden by git
+   * itself, so they never appear here.
+   *
+   * @param worktreePath - Path to the worktree to check
+   * @returns Relative paths of dirty entries; empty for a clean tree
+   */
+  async getDirtyPaths(worktreePath: string): Promise<string[]> {
+    const gitInWorktree = simpleGit(worktreePath)
+    const status = await gitInWorktree.status()
+    return status.files.map((file) => file.path)
   }
 
   /**

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -741,13 +741,14 @@ export class GitHelper {
     for (let i = 0; i < trackedFiles.length; i += chunkSize) {
       const chunk = trackedFiles.slice(i, i + chunkSize)
       try {
-        await gitInWorktree.raw(['update-index', '--skip-worktree', ...chunk])
+        // `--` prevents a file name starting with `-` from being parsed as a flag
+        await gitInWorktree.raw(['update-index', '--skip-worktree', '--', ...chunk])
         filesMarked += chunk.length
       } catch {
         // Batch failed - retry per file so one bad path cannot abort the rest
         for (const file of chunk) {
           try {
-            await gitInWorktree.raw(['update-index', '--skip-worktree', file])
+            await gitInWorktree.raw(['update-index', '--skip-worktree', '--', file])
             filesMarked++
           } catch {
             failedFiles.push(file)

--- a/src/utils/worktreeSetup.ts
+++ b/src/utils/worktreeSetup.ts
@@ -173,6 +173,19 @@ export class WorktreeSetupOrchestrator {
         throw new Error(`Worktree path does not exist: ${worktreePath}`)
       }
 
+      // ============================================================
+      // Phase 2: Create Checkpoint
+      // ============================================================
+      this.reportProgress(options.onProgress, SetupPhase.CHECKPOINT, 'Creating checkpoint')
+
+      // Create transaction checkpoint
+      // Snapshot worktree state for potential rollback. This MUST happen
+      // before any operation that can throw (including symlink planning
+      // below) - otherwise a failure there leaves rollback() with no
+      // 'worktree' checkpoint, and the already-created git worktree is never
+      // cleaned up.
+      this.transaction.createCheckpoint('worktree', { path: worktreePath })
+
       // Plan symlinks once: matched items minus (in strict mode) git-tracked
       // paths. The symlink phases and rsync exclusions all consume this plan so
       // every phase agrees on what will be symlinked. Tracked items that ARE
@@ -205,15 +218,6 @@ export class WorktreeSetupOrchestrator {
       }
 
       // ============================================================
-      // Phase 2: Create Checkpoint
-      // ============================================================
-      this.reportProgress(options.onProgress, SetupPhase.CHECKPOINT, 'Creating checkpoint')
-
-      // Create transaction checkpoint
-      // Snapshot worktree state for potential rollback
-      this.transaction.createCheckpoint('worktree', { path: worktreePath })
-
-      // ============================================================
       // Phase 3: Symlinks (Before Rsync)
       // ============================================================
       if (!options.skipSymlink && symlinkConfig.beforeRsync) {
@@ -239,7 +243,7 @@ export class WorktreeSetupOrchestrator {
       // ============================================================
       // Phase 4: Rsync
       // ============================================================
-      if (!options.skipRsync && this.config.rsync.enabled) {
+      if (!options.skipRsync && rsyncConfig.enabled) {
         this.reportProgress(options.onProgress, SetupPhase.RSYNC, 'Syncing files with rsync...')
 
         // Which files may cross worktrees depends on the mode:

--- a/src/utils/worktreeSetup.ts
+++ b/src/utils/worktreeSetup.ts
@@ -76,6 +76,12 @@ export interface SetupResult {
   rsyncResult?: RsyncResult
   symlinkResult?: SymlinkResult
   skipWorktreeResult?: { filesMarked: number; success: boolean }
+  /**
+   * Whether `git status` in the new worktree is empty after setup (files marked
+   * skip-worktree are hidden by git itself). Undefined when the check could not
+   * run (e.g. on the error path, after rollback).
+   */
+  cleanTree?: boolean
   duration: number
   warnings: string[]
   rolledBack: boolean
@@ -167,6 +173,37 @@ export class WorktreeSetupOrchestrator {
         throw new Error(`Worktree path does not exist: ${worktreePath}`)
       }
 
+      // Plan symlinks once: matched items minus (in strict mode) git-tracked
+      // paths. The symlink phases and rsync exclusions all consume this plan so
+      // every phase agrees on what will be symlinked. Tracked items that ARE
+      // symlinked (allowTracked, the default) get hidden from git status via
+      // skip-worktree in Phase 5.5.
+      let symlinkItems: string[] = []
+      if (!options.skipSymlink && symlinkConfig.patterns.length > 0) {
+        const matches = await this.symlinkHelper.matchPatterns(
+          sourceTreePath,
+          symlinkConfig.patterns
+        )
+
+        if (symlinkConfig.allowTracked ?? true) {
+          symlinkItems = matches
+        } else {
+          const trackedItems = await this.gitHelper.filterTrackedPaths(worktreePath, matches)
+          if (trackedItems.length === 0) {
+            symlinkItems = matches
+          } else {
+            const trackedSet = new Set(trackedItems)
+            symlinkItems = matches.filter((item) => !trackedSet.has(item))
+            warnings.push(
+              `Skipped symlinking git-tracked path(s): ${trackedItems.join(', ')}. ` +
+                `Symlinking tracked paths makes git status show them as deleted or modified. ` +
+                `Add them to .gitignore (and remove them from the index), or set ` +
+                `symlink.allowTracked = true to symlink them anyway.`
+            )
+          }
+        }
+      }
+
       // ============================================================
       // Phase 2: Create Checkpoint
       // ============================================================
@@ -179,35 +216,18 @@ export class WorktreeSetupOrchestrator {
       // ============================================================
       // Phase 3: Symlinks (Before Rsync)
       // ============================================================
-      if (!options.skipSymlink && this.config.symlink.beforeRsync) {
+      if (!options.skipSymlink && symlinkConfig.beforeRsync) {
         this.reportProgress(
           options.onProgress,
           SetupPhase.SYMLINK_BEFORE,
           'Creating symlinks (before rsync)'
         )
 
-        // Remove git-checked-out files that will be symlinked
-        // Git automatically checks out tracked files when creating worktrees
-        const filesToSymlink = await this.symlinkHelper.matchPatterns(
-          sourceTreePath,
-          symlinkConfig.patterns
-        )
-        for (const file of filesToSymlink) {
-          const targetPath = await import('path').then((p) => p.default.join(worktreePath, file))
-          if (await fs.pathExists(targetPath)) {
-            await fs.remove(targetPath)
-          }
-        }
-
-        // Create symlinks before rsync
-        symlinkResult = await this.symlinkHelper.createSymlinks(
+        symlinkResult = await this.createPlannedSymlinks(
           sourceTreePath,
           worktreePath,
           symlinkConfig,
-          {
-            replaceExisting: true,
-            skipConflicts: true,
-          }
+          symlinkItems
         )
 
         // Add warnings for skipped conflicts
@@ -222,19 +242,46 @@ export class WorktreeSetupOrchestrator {
       if (!options.skipRsync && this.config.rsync.enabled) {
         this.reportProgress(options.onProgress, SetupPhase.RSYNC, 'Syncing files with rsync...')
 
-        const sourceCommit = await this.gitHelper.getWorktreeCommit(sourceTreePath)
-        const targetCommit = await this.gitHelper.getWorktreeCommit(worktreePath)
+        // Which files may cross worktrees depends on the mode:
+        // - onlyUntracked (default): sync only gitignored artifacts (.venv,
+        //   node_modules, caches). Tracked files come from the target's own
+        //   checkout, so nothing tracked can be clobbered regardless of which
+        //   commits the two worktrees are on.
+        // - full mirror (onlyUntracked=false): copy the whole source tree, but
+        //   only when both worktrees are on the same commit - otherwise the
+        //   source branch's tracked files would dirty the target.
+        const onlyUntracked = rsyncConfig.onlyUntracked ?? true
+        let filesFrom: string[] | undefined
+        let runRsync = true
 
-        if (sourceCommit !== targetCommit) {
-          warnings.push(
-            `Skipped rsync because source worktree (${sourceCommit.slice(0, 7)}) differs from target worktree (${targetCommit.slice(0, 7)}). This prevents tracked files from being copied across different commits.`
-          )
-          this.reportProgress(
-            options.onProgress,
-            SetupPhase.RSYNC,
-            'Skipped rsync due to commit mismatch'
-          )
+        if (onlyUntracked) {
+          filesFrom = await this.gitHelper.listIgnoredFiles(sourceTreePath)
+          if (filesFrom.length === 0) {
+            runRsync = false
+            this.reportProgress(
+              options.onProgress,
+              SetupPhase.RSYNC,
+              'Skipped rsync - no ignored files to sync'
+            )
+          }
         } else {
+          const sourceCommit = await this.gitHelper.getWorktreeCommit(sourceTreePath)
+          const targetCommit = await this.gitHelper.getWorktreeCommit(worktreePath)
+
+          if (sourceCommit !== targetCommit) {
+            runRsync = false
+            warnings.push(
+              `Skipped rsync because source worktree (${sourceCommit.slice(0, 7)}) differs from target worktree (${targetCommit.slice(0, 7)}). This prevents tracked files from being copied across different commits.`
+            )
+            this.reportProgress(
+              options.onProgress,
+              SetupPhase.RSYNC,
+              'Skipped rsync due to commit mismatch'
+            )
+          }
+        }
+
+        if (runRsync) {
           // Check rsync is installed
           const { RsyncNotInstalledError } = await import('./fileOps.js')
           if (!(await this.rsyncHelper.isInstalled())) {
@@ -249,41 +296,33 @@ export class WorktreeSetupOrchestrator {
 
           // ALWAYS exclude files/directories that will be symlinked (regardless of beforeRsync setting)
           // This prevents rsync from copying items that should be symlinks
-          if (!options.skipSymlink && symlinkConfig.patterns.length > 0) {
-            // Match symlink patterns against source directory to find items that will be symlinked
-            const itemsToSymlink = await this.symlinkHelper.matchPatterns(
-              sourceTreePath,
-              symlinkConfig.patterns
-            )
-
-            // Generate rsync exclude patterns with proper format for files vs directories
-            // Directories need trailing '/' to exclude the directory and all contents
-            const pathModule = await import('path')
-            for (const item of itemsToSymlink) {
-              const fullPath = pathModule.default.join(sourceTreePath, item)
-              try {
-                const stats = await fs.stat(fullPath)
-                if (stats.isDirectory()) {
-                  // For directories: use trailing slash to exclude directory and contents
-                  excludePatterns.push(`/${item}/`)
-                } else {
-                  // For files: exclude the specific file
-                  excludePatterns.push(`/${item}`)
-                }
-              } catch (statError) {
-                // Default to file pattern if stat fails, but warn about potential issues
-                const errMsg = statError instanceof Error ? statError.message : String(statError)
-                warnings.push(
-                  `Could not stat '${item}' for rsync exclusion (using file pattern): ${errMsg}`
-                )
+          // Directories need trailing '/' to exclude the directory and all contents
+          const pathModule = await import('path')
+          for (const item of symlinkItems) {
+            const fullPath = pathModule.default.join(sourceTreePath, item)
+            try {
+              const stats = await fs.stat(fullPath)
+              if (stats.isDirectory()) {
+                // For directories: use trailing slash to exclude directory and contents
+                excludePatterns.push(`/${item}/`)
+              } else {
+                // For files: exclude the specific file
                 excludePatterns.push(`/${item}`)
               }
+            } catch (statError) {
+              // Default to file pattern if stat fails, but warn about potential issues
+              const errMsg = statError instanceof Error ? statError.message : String(statError)
+              warnings.push(
+                `Could not stat '${item}' for rsync exclusion (using file pattern): ${errMsg}`
+              )
+              excludePatterns.push(`/${item}`)
             }
           }
 
           // Execute rsync with progress callback
           rsyncResult = await this.rsyncHelper.rsync(sourceTreePath, worktreePath, rsyncConfig, {
             excludePatterns,
+            filesFrom,
             onProgress: options.onProgress
               ? (progress: RsyncProgressData): void => {
                   const message = `Synced: ${progress.filesTransferred} files`
@@ -297,37 +336,19 @@ export class WorktreeSetupOrchestrator {
       // ============================================================
       // Phase 5: Symlinks (After Rsync)
       // ============================================================
-      if (!options.skipSymlink && !this.config.symlink.beforeRsync) {
+      if (!options.skipSymlink && !symlinkConfig.beforeRsync) {
         this.reportProgress(
           options.onProgress,
           SetupPhase.SYMLINK_AFTER,
           'Creating symlinks (after rsync)'
         )
 
-        // Remove git-checked-out files that will be symlinked
-        // Git automatically checks out tracked files when creating worktrees
-        const filesToSymlink = await this.symlinkHelper.matchPatterns(
-          sourceTreePath,
-          symlinkConfig.patterns
-        )
-        const path = await import('path')
-        for (const file of filesToSymlink) {
-          const targetPath = path.default.join(worktreePath, file)
-          if (await fs.pathExists(targetPath)) {
-            await fs.remove(targetPath)
-          }
-        }
-
-        // Create symlinks after rsync
         // Rsync already excluded these files, so no conflicts expected
-        symlinkResult = await this.symlinkHelper.createSymlinks(
+        symlinkResult = await this.createPlannedSymlinks(
           sourceTreePath,
           worktreePath,
           symlinkConfig,
-          {
-            replaceExisting: true,
-            skipConflicts: true,
-          }
+          symlinkItems
         )
 
         // Add warnings for any conflicts (shouldn't happen since rsync excluded them)
@@ -401,6 +422,33 @@ export class WorktreeSetupOrchestrator {
         warnings.push('Rsync reported unsuccessful completion')
       }
 
+      // Clean-tree invariant: after setup, `git status` in the new worktree
+      // must be empty (skip-worktree'd files are hidden by git itself). A dirty
+      // tree here means setup polluted the checkout - surface it immediately
+      // instead of letting the user discover it downstream. The symlinks pando
+      // itself created are intentional state, not pollution: a symlink over a
+      // tracked directory shows as untracked even when its files are hidden.
+      let cleanTree: boolean | undefined
+      try {
+        const symlinkItemSet = new Set(symlinkItems)
+        const dirtyPaths = (await this.gitHelper.getDirtyPaths(worktreePath)).filter(
+          (dirtyPath) => !symlinkItemSet.has(dirtyPath)
+        )
+        cleanTree = dirtyPaths.length === 0
+        if (!cleanTree) {
+          const shown = dirtyPaths.slice(0, 10).join(', ')
+          const more = dirtyPaths.length > 10 ? ` (+${dirtyPaths.length - 10} more)` : ''
+          warnings.push(
+            `Worktree is not clean after setup (${dirtyPaths.length} path(s)): ${shown}${more}. ` +
+              `Likely cause: symlinked tracked files that could not be hidden via skip-worktree, ` +
+              `or rsync copying tracked files (rsync.onlyUntracked = false).`
+          )
+        }
+      } catch {
+        // Status check is best-effort; setup itself succeeded
+        cleanTree = undefined
+      }
+
       // ============================================================
       // Phase 7: Complete
       // ============================================================
@@ -413,6 +461,7 @@ export class WorktreeSetupOrchestrator {
         rsyncResult,
         symlinkResult,
         skipWorktreeResult,
+        cleanTree,
         duration,
         warnings,
         rolledBack: false,
@@ -517,6 +566,41 @@ export class WorktreeSetupOrchestrator {
       warnings.push(`Rollback failed: ${errorMsg}. Manual cleanup may be required.`)
       return { rolledBack: false, warnings }
     }
+  }
+
+  /**
+   * Remove the checked-out copies of the planned items and symlink them to the
+   * source tree. Shared by the before-rsync and after-rsync symlink phases.
+   *
+   * @param sourceTreePath - Main worktree the symlinks point into
+   * @param worktreePath - New worktree receiving the symlinks
+   * @param symlinkConfig - Merged symlink configuration
+   * @param symlinkItems - Precomputed relative paths to symlink (the plan)
+   * @returns Result of the symlink operations
+   */
+  private async createPlannedSymlinks(
+    sourceTreePath: string,
+    worktreePath: string,
+    symlinkConfig: SymlinkConfig,
+    symlinkItems: string[]
+  ): Promise<SymlinkResult> {
+    const fs = (await import('fs-extra')).default
+    const path = await import('path')
+
+    // Remove git-checked-out files that will be symlinked
+    // Git automatically checks out tracked files when creating worktrees
+    for (const item of symlinkItems) {
+      const targetPath = path.default.join(worktreePath, item)
+      if (await fs.pathExists(targetPath)) {
+        await fs.remove(targetPath)
+      }
+    }
+
+    return this.symlinkHelper.createSymlinks(sourceTreePath, worktreePath, symlinkConfig, {
+      replaceExisting: true,
+      skipConflicts: true,
+      items: symlinkItems,
+    })
   }
 
   /**

--- a/test/config/env.test.ts
+++ b/test/config/env.test.ts
@@ -181,6 +181,13 @@ describe('parseEnvValue', () => {
     expect(parseEnvValue('PANDO_WORKTREE_USE_PROJECT_SUBFOLDER', 'false')).toBe(false)
   })
 
+  it('should parse TRACKED variants as boolean', () => {
+    expect(parseEnvValue('PANDO_RSYNC_ONLY_UNTRACKED', 'true')).toBe(true)
+    expect(parseEnvValue('PANDO_RSYNC_ONLY_UNTRACKED', 'false')).toBe(false)
+    expect(parseEnvValue('PANDO_SYMLINK_ALLOW_TRACKED', 'yes')).toBe(true)
+    expect(parseEnvValue('PANDO_SYMLINK_ALLOW_TRACKED', 'no')).toBe(false)
+  })
+
   it('should return string for unknown keys', () => {
     expect(parseEnvValue('PANDO_UNKNOWN_KEY', 'value')).toBe('value')
   })
@@ -229,6 +236,17 @@ describe('parseEnvVars', () => {
         relative: true,
         beforeRsync: false,
       },
+    })
+  })
+
+  it('should parse safety-mode variables', () => {
+    const env = {
+      PANDO_RSYNC_ONLY_UNTRACKED: 'false',
+      PANDO_SYMLINK_ALLOW_TRACKED: 'true',
+    }
+    expect(parseEnvVars(env)).toEqual({
+      rsync: { onlyUntracked: false },
+      symlink: { allowTracked: true },
     })
   })
 

--- a/test/e2e/commands/add.e2e.test.ts
+++ b/test/e2e/commands/add.e2e.test.ts
@@ -426,11 +426,13 @@ describe('pando add (E2E)', () => {
     })
 
     it('should show valid MB value greater than 0 for rsync operations', async () => {
-      // Create a file larger than 1MB to ensure measurable rsync output
+      // Create a file larger than 1MB inside the gitignored .venv/ directory:
+      // with the default rsync.onlyUntracked, only gitignored artifacts are
+      // synced, so a plain untracked file at the repo root would not be.
       await container.exec([
         'sh',
         '-c',
-        `dd if=/dev/zero of=${repoPath}/large-file.bin bs=1M count=2 2>/dev/null`,
+        `mkdir -p ${repoPath}/.venv && dd if=/dev/zero of=${repoPath}/.venv/large-file.bin bs=1M count=2 2>/dev/null`,
       ])
 
       // Run pando add with human-readable output
@@ -446,7 +448,7 @@ describe('pando add (E2E)', () => {
 
       // Verify the file was actually synced to the new worktree
       const worktreePath = `${repoPath}/../worktrees/rsync-mb-test`
-      const fileCheck = await container.exec(['ls', '-la', `${worktreePath}/large-file.bin`])
+      const fileCheck = await container.exec(['ls', '-la', `${worktreePath}/.venv/large-file.bin`])
       expect(fileCheck.exitCode, `Large file should have been synced to worktree`).toBe(0)
 
       // Extract MB value from "Files synced: X files (Y MB)" pattern
@@ -640,7 +642,7 @@ describe('pando add (E2E)', () => {
       expect(actualHeadResult.stdout.trim()).toBe(baseCommit)
     })
 
-    it('skips rsync and leaves the target clean when source and target commits differ', async () => {
+    it('leaves the target clean when source and target commits differ (default onlyUntracked)', async () => {
       const commitRepo = await setupGitRepo(container, {
         name: 'commit-clean-rsync-repo',
         files: [{ path: 'tracked.txt', content: 'base' }],
@@ -664,6 +666,63 @@ describe('pando add (E2E)', () => {
         '../worktrees/commit-clean-target',
         '--branch',
         'commit-clean-target',
+        '--commit',
+        baseCommit,
+      ])
+
+      expectJsonSuccess(result)
+      expect(result.json?.setup).toBeDefined()
+      // No gitignored files exist in this repo, so onlyUntracked rsync has
+      // nothing to sync - unrelated to the commit mismatch
+      expect((result.json?.setup as { rsync: unknown }).rsync).toBeNull()
+      expect((result.json?.setup as { cleanTree: boolean }).cleanTree).toBe(true)
+
+      const worktreePath = (result.json?.worktree as { path: string }).path
+      const statusResult = await container.exec([
+        'sh',
+        '-c',
+        `cd ${worktreePath} && git status --short`,
+      ])
+      expect(statusResult.stdout.trim()).toBe('')
+
+      const contentResult = await container.exec([
+        'sh',
+        '-c',
+        `cd ${worktreePath} && cat tracked.txt`,
+      ])
+      expect(contentResult.stdout.trim()).toBe('base')
+    })
+
+    it('skips rsync with a warning on commit mismatch when onlyUntracked=false (legacy mirror mode)', async () => {
+      const commitRepo = await setupGitRepo(container, {
+        name: 'commit-clean-rsync-legacy-repo',
+        files: [{ path: 'tracked.txt', content: 'base' }],
+      })
+
+      await container.exec([
+        'sh',
+        '-c',
+        `cd ${commitRepo} && printf '[rsync]\\nonlyUntracked = false\\n' > .pando.toml && git add .pando.toml && git commit -m "add config"`,
+      ])
+
+      const baseCommitResult = await container.exec([
+        'sh',
+        '-c',
+        `cd ${commitRepo} && git rev-parse HEAD`,
+      ])
+      const baseCommit = baseCommitResult.stdout.trim()
+
+      await container.exec([
+        'sh',
+        '-c',
+        `cd ${commitRepo} && git checkout -b source-dirtying-feature-legacy && echo feature > tracked.txt && git add tracked.txt && git commit -m feature`,
+      ])
+
+      const result = await pandoAdd(container, commitRepo, [
+        '--path',
+        '../worktrees/commit-clean-target-legacy',
+        '--branch',
+        'commit-clean-target-legacy',
         '--commit',
         baseCommit,
       ])

--- a/test/e2e/commands/add.e2e.test.ts
+++ b/test/e2e/commands/add.e2e.test.ts
@@ -22,7 +22,12 @@ describe('pando add (E2E)', () => {
       files: [
         { path: 'package.json', content: '{"name": "test"}' },
         { path: 'src/index.ts', content: 'export const main = () => {}' },
+        // .gitignore is written before `git add .`, so node_modules and .venv
+        // stay untracked - the artifact set that default rsync
+        // (onlyUntracked) carries into new worktrees
+        { path: '.gitignore', content: 'node_modules/\n.venv/' },
         { path: 'node_modules/.bin/test', content: 'binary' },
+        { path: '.venv/cache.bin', content: 'artifact' },
       ],
       branches: ['existing-branch'],
     })
@@ -96,7 +101,7 @@ describe('pando add (E2E)', () => {
   })
 
   describe('rsync integration', () => {
-    it('should sync files with rsync enabled', async () => {
+    it('should sync ignored artifacts with rsync enabled', async () => {
       const result = await pandoAdd(container, repoPath, [
         '--branch',
         'rsync-test',
@@ -108,6 +113,16 @@ describe('pando add (E2E)', () => {
       // rsync result should be present (not null/undefined)
       expect(result.json?.setup?.rsync).toBeDefined()
       expect(result.json?.setup?.rsync).not.toBeNull()
+      // The clean-tree invariant: setup must not dirty the new checkout
+      expect(result.json?.setup?.cleanTree).toBe(true)
+
+      // Gitignored artifacts arrive in the new worktree
+      const artifactCheck = await container.exec([
+        'sh',
+        '-c',
+        `cat ${repoPath}/../worktrees/rsync-test/.venv/cache.bin`,
+      ])
+      expect(artifactCheck.stdout.trim()).toBe('artifact')
     })
 
     it('should skip rsync when --skip-rsync is set', async () => {

--- a/test/integration/worktreeSetup.integration.test.ts
+++ b/test/integration/worktreeSetup.integration.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import fs from 'fs-extra'
+import * as os from 'os'
+import * as path from 'path'
+import { GitHelper } from '../../src/utils/git'
+import { createWorktreeSetupOrchestrator } from '../../src/utils/worktreeSetup'
+import { DEFAULT_CONFIG, type PandoConfig } from '../../src/config/schema'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Integration regression tests for the "pando add leaves worktree dirty" bug
+ * report. Real git repositories and real rsync - no mocks - covering:
+ *
+ * 1. skip-worktree filtering (mixed ignored + tracked symlink patterns)
+ * 2. rsync tracked-file protection across branches
+ * 3. tracked-symlink guard (symlink.allowTracked)
+ * 4. clean-tree invariant end-to-end
+ * 5. source-worktree integrity (rsync/symlink ordering must never write into
+ *    the shared source tree)
+ */
+
+describe('worktree setup integration (real git + rsync)', () => {
+  let tmpRoot: string
+  let repoDir: string
+  let worktreeDir: string
+  let gitHelper: GitHelper
+
+  const git = (args: string[], cwd: string = repoDir) =>
+    execFileAsync('git', args, { cwd, env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null' } })
+
+  const gitStatus = async (cwd: string): Promise<string> => {
+    const { stdout } = await git(['status', '--porcelain'], cwd)
+    return stdout.trim()
+  }
+
+  const write = async (relPath: string, content: string, base: string = repoDir) => {
+    const fullPath = path.join(base, relPath)
+    await fs.ensureDir(path.dirname(fullPath))
+    await fs.writeFile(fullPath, content)
+  }
+
+  /** Recursive snapshot of a tree (path -> content or symlink target), excluding .git */
+  const snapshotTree = async (dir: string): Promise<Map<string, string>> => {
+    const snapshot = new Map<string, string>()
+    const walk = async (current: string): Promise<void> => {
+      for (const entry of await fs.readdir(current)) {
+        if (entry === '.git') continue
+        const fullPath = path.join(current, entry)
+        const relPath = path.relative(dir, fullPath)
+        const stats = await fs.lstat(fullPath)
+        if (stats.isSymbolicLink()) {
+          snapshot.set(relPath, `symlink:${await fs.readlink(fullPath)}`)
+        } else if (stats.isDirectory()) {
+          await walk(fullPath)
+        } else {
+          snapshot.set(relPath, (await fs.readFile(fullPath)).toString())
+        }
+      }
+    }
+    await walk(dir)
+    return snapshot
+  }
+
+  const makeConfig = (overrides: {
+    rsync?: Partial<PandoConfig['rsync']>
+    symlink?: Partial<PandoConfig['symlink']>
+  }): PandoConfig => ({
+    ...DEFAULT_CONFIG,
+    rsync: { ...DEFAULT_CONFIG.rsync, ...overrides.rsync },
+    symlink: { ...DEFAULT_CONFIG.symlink, ...overrides.symlink },
+  })
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'pando-integration-'))
+    repoDir = path.join(tmpRoot, 'repo')
+    worktreeDir = path.join(tmpRoot, 'worktrees', 'feature')
+    await fs.ensureDir(repoDir)
+
+    await git(['init', '-q', '-b', 'main'])
+    await git(['config', 'user.email', 'test@pando.dev'])
+    await git(['config', 'user.name', 'Pando Test'])
+
+    // Tracked content on main
+    await write('src/app.py', 'print("main")\n')
+    await write('CLAUDE.md', '# claude instructions\n')
+    await write('.claude/settings.json', '{"shared": true}\n')
+    await write('.gitignore', '.env\n.venv/\n')
+    await git(['add', '-A'])
+    await git(['commit', '-qm', 'initial commit'])
+
+    // A feature branch whose tracked tree DIFFERS from main
+    await git(['switch', '-qc', 'feature'])
+    await write('src/app.py', 'print("feature")\n')
+    await write('feature-only.py', 'print("only on feature")\n')
+    await git(['add', '-A'])
+    await git(['commit', '-qm', 'feature work'])
+    await git(['switch', '-q', 'main'])
+
+    // Untracked state in the source worktree:
+    await write('.env', 'SECRET=1\n') // gitignored, symlink pattern
+    await write('.venv/lib/pkg.py', 'venv artifact\n') // gitignored artifact
+    await write('wip-note.md', 'work in progress\n') // untracked, NOT ignored
+
+    // The worktree under test, on the existing feature branch (different commit)
+    await fs.ensureDir(path.dirname(worktreeDir))
+    await git(['worktree', 'add', '-q', worktreeDir, 'feature'])
+
+    gitHelper = new GitHelper(repoDir)
+  })
+
+  afterEach(async () => {
+    await fs.remove(tmpRoot)
+  })
+
+  it('leaves a clean tree for an existing branch with the default config', async () => {
+    // Mirrors the reported repro: existing branch, mixed ignored+tracked
+    // symlink patterns, rsync enabled
+    const config = makeConfig({
+      symlink: { patterns: ['.env', 'CLAUDE.md', '.claude/'] },
+    })
+
+    const result = await createWorktreeSetupOrchestrator(gitHelper, config).setupNewWorktree(
+      worktreeDir
+    )
+
+    expect(result.success).toBe(true)
+
+    // Tracked content comes from the branch's own checkout, never from rsync
+    expect(await fs.readFile(path.join(worktreeDir, 'src/app.py'), 'utf8')).toBe(
+      'print("feature")\n'
+    )
+    expect(await fs.pathExists(path.join(worktreeDir, 'feature-only.py'))).toBe(true)
+
+    // Ignored artifacts arrive; non-ignored untracked WIP does not
+    expect(await fs.readFile(path.join(worktreeDir, '.venv/lib/pkg.py'), 'utf8')).toBe(
+      'venv artifact\n'
+    )
+    expect(await fs.pathExists(path.join(worktreeDir, 'wip-note.md'))).toBe(false)
+
+    // All patterns are symlinked, tracked ones included (allowTracked default)
+    expect((await fs.lstat(path.join(worktreeDir, '.env'))).isSymbolicLink()).toBe(true)
+    expect((await fs.lstat(path.join(worktreeDir, 'CLAUDE.md'))).isSymbolicLink()).toBe(true)
+    expect((await fs.lstat(path.join(worktreeDir, '.claude'))).isSymbolicLink()).toBe(true)
+
+    // The mixed ignored+tracked pattern list must not abort the skip-worktree
+    // batch: CLAUDE.md and .claude/settings.json get marked, .env is filtered
+    expect(result.skipWorktreeResult).toBeDefined()
+    expect(result.skipWorktreeResult?.success).toBe(true)
+    expect(result.skipWorktreeResult?.filesMarked).toBe(2)
+    expect(result.warnings.some((w) => w.includes('Could not mark'))).toBe(false)
+
+    // Status shows nothing except the intentional .claude dir symlink, which
+    // the clean-tree check tolerates
+    expect(result.cleanTree).toBe(true)
+    expect(await gitStatus(worktreeDir)).toBe('?? .claude')
+  })
+
+  it('skips tracked symlink patterns with a warning when allowTracked=false', async () => {
+    const config = makeConfig({
+      symlink: { patterns: ['.env', 'CLAUDE.md', '.claude/'], allowTracked: false },
+    })
+
+    const result = await createWorktreeSetupOrchestrator(gitHelper, config).setupNewWorktree(
+      worktreeDir
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.cleanTree).toBe(true)
+    expect(await gitStatus(worktreeDir)).toBe('')
+
+    // Ignored pattern is symlinked; tracked patterns stay as checked-out files
+    expect((await fs.lstat(path.join(worktreeDir, '.env'))).isSymbolicLink()).toBe(true)
+    expect((await fs.lstat(path.join(worktreeDir, 'CLAUDE.md'))).isFile()).toBe(true)
+    expect((await fs.lstat(path.join(worktreeDir, '.claude'))).isDirectory()).toBe(true)
+    expect(
+      result.warnings.some(
+        (w) =>
+          w.includes('Skipped symlinking git-tracked path(s)') &&
+          w.includes('CLAUDE.md') &&
+          w.includes('.claude')
+      )
+    ).toBe(true)
+  })
+
+  it('never modifies the source worktree (rsync + beforeRsync symlinks)', async () => {
+    const config = makeConfig({
+      symlink: { patterns: ['.env', 'CLAUDE.md', '.claude/'], allowTracked: true },
+    })
+
+    const sourceBefore = await snapshotTree(repoDir)
+    const sourceStatusBefore = await gitStatus(repoDir)
+
+    await createWorktreeSetupOrchestrator(gitHelper, config).setupNewWorktree(worktreeDir)
+
+    const sourceAfter = await snapshotTree(repoDir)
+    expect(Object.fromEntries(sourceAfter)).toEqual(Object.fromEntries(sourceBefore))
+    expect(await gitStatus(repoDir)).toBe(sourceStatusBefore)
+  })
+
+  it('full mirror mode still refuses to rsync across different commits', async () => {
+    const config = makeConfig({
+      rsync: { onlyUntracked: false },
+      symlink: { patterns: ['.env'] },
+    })
+
+    const result = await createWorktreeSetupOrchestrator(gitHelper, config).setupNewWorktree(
+      worktreeDir
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.rsyncResult).toBeUndefined()
+    expect(result.warnings.some((w) => w.includes('Skipped rsync because source worktree'))).toBe(
+      true
+    )
+    // Tracked files stay pristine because nothing was copied
+    expect(result.cleanTree).toBe(true)
+    expect(await fs.readFile(path.join(worktreeDir, 'src/app.py'), 'utf8')).toBe(
+      'print("feature")\n'
+    )
+  })
+
+  it('a tracked file that differs between branches is never clobbered by rsync', async () => {
+    // Regression for the reported defect: rsync copied the source branch's
+    // tracked tree over the target checkout (src/app.py differs between
+    // main and feature)
+    const config = makeConfig({ symlink: { patterns: [] } })
+
+    const result = await createWorktreeSetupOrchestrator(gitHelper, config).setupNewWorktree(
+      worktreeDir
+    )
+
+    expect(result.success).toBe(true)
+    expect(await fs.readFile(path.join(worktreeDir, 'src/app.py'), 'utf8')).toBe(
+      'print("feature")\n'
+    )
+    expect(await gitStatus(worktreeDir)).toBe('')
+  })
+})

--- a/test/utils/fileOps.test.ts
+++ b/test/utils/fileOps.test.ts
@@ -655,6 +655,130 @@ describe('RsyncHelper', () => {
     })
   })
 
+  describe('rsync with filesFrom', () => {
+    let syncDir: string
+
+    beforeEach(async () => {
+      syncDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pando-filesfrom-test-'))
+    })
+
+    afterEach(async () => {
+      await fs.remove(syncDir)
+    })
+
+    const config = { enabled: true, flags: ['--archive'], exclude: [] }
+
+    it('copies only the listed files, not the rest of the source tree', async () => {
+      if (!(await rsyncHelper.isInstalled())) return
+
+      const src = path.join(syncDir, 'src')
+      const dst = path.join(syncDir, 'dst')
+      await fs.ensureDir(path.join(src, 'artifacts'))
+      await fs.ensureDir(dst)
+      await fs.writeFile(path.join(src, 'tracked.txt'), 'tracked content')
+      await fs.writeFile(path.join(src, 'artifacts', 'cache.bin'), 'artifact content')
+
+      const result = await rsyncHelper.rsync(src, dst, config, {
+        filesFrom: ['artifacts/cache.bin'],
+      })
+
+      expect(result.success).toBe(true)
+      expect(await fs.pathExists(path.join(dst, 'artifacts', 'cache.bin'))).toBe(true)
+      expect(await fs.pathExists(path.join(dst, 'tracked.txt'))).toBe(false)
+    })
+
+    it('transfers nothing and skips spawning when the list is empty', async () => {
+      const src = path.join(syncDir, 'src')
+      const dst = path.join(syncDir, 'dst')
+      await fs.ensureDir(src)
+      await fs.ensureDir(dst)
+      await fs.writeFile(path.join(src, 'tracked.txt'), 'tracked content')
+
+      const result = await rsyncHelper.rsync(src, dst, config, { filesFrom: [] })
+
+      expect(result.success).toBe(true)
+      expect(result.filesTransferred).toBe(0)
+      expect(await fs.pathExists(path.join(dst, 'tracked.txt'))).toBe(false)
+      // Nothing happened, so nothing should be recorded for rollback
+      expect(transaction.getOperations()).toHaveLength(0)
+    })
+
+    it('still applies exclude patterns on top of the file list', async () => {
+      if (!(await rsyncHelper.isInstalled())) return
+
+      const src = path.join(syncDir, 'src')
+      const dst = path.join(syncDir, 'dst')
+      await fs.ensureDir(path.join(src, 'htmlcov'))
+      await fs.ensureDir(path.join(src, 'artifacts'))
+      await fs.ensureDir(dst)
+      await fs.writeFile(path.join(src, 'htmlcov', 'index.html'), 'coverage')
+      await fs.writeFile(path.join(src, 'artifacts', 'cache.bin'), 'artifact')
+
+      const result = await rsyncHelper.rsync(
+        src,
+        dst,
+        { ...config, exclude: ['htmlcov/'] },
+        { filesFrom: ['htmlcov/index.html', 'artifacts/cache.bin'] }
+      )
+
+      expect(result.success).toBe(true)
+      expect(await fs.pathExists(path.join(dst, 'artifacts', 'cache.bin'))).toBe(true)
+      expect(await fs.pathExists(path.join(dst, 'htmlcov', 'index.html'))).toBe(false)
+    })
+
+    it('handles file names with spaces and special characters', async () => {
+      if (!(await rsyncHelper.isInstalled())) return
+
+      const src = path.join(syncDir, 'src')
+      const dst = path.join(syncDir, 'dst')
+      await fs.ensureDir(src)
+      await fs.ensureDir(dst)
+      const trickyName = 'my file (v2).txt'
+      await fs.writeFile(path.join(src, trickyName), 'tricky')
+
+      const result = await rsyncHelper.rsync(src, dst, config, { filesFrom: [trickyName] })
+
+      expect(result.success).toBe(true)
+      expect(await fs.pathExists(path.join(dst, trickyName))).toBe(true)
+    })
+  })
+
+  describe('filterExcludedPaths', () => {
+    it('excludes directory patterns (trailing slash) at any depth', () => {
+      const result = RsyncHelper.filterExcludedPaths(
+        ['htmlcov/index.html', 'sub/htmlcov/x.html', 'src/app.py'],
+        ['htmlcov/']
+      )
+      expect(result).toEqual(['src/app.py'])
+    })
+
+    it('excludes glob patterns against basenames at any depth', () => {
+      const result = RsyncHelper.filterExcludedPaths(
+        ['debug.log', 'logs/app.log', 'src/app.py'],
+        ['*.log']
+      )
+      expect(result).toEqual(['src/app.py'])
+    })
+
+    it('anchors leading-slash patterns to the transfer root', () => {
+      const result = RsyncHelper.filterExcludedPaths(
+        ['dist/bundle.js', 'packages/lib/dist/bundle.js'],
+        ['/dist/']
+      )
+      expect(result).toEqual(['packages/lib/dist/bundle.js'])
+    })
+
+    it('matches dotfiles', () => {
+      const result = RsyncHelper.filterExcludedPaths(['.git/config', '.env'], ['.git'])
+      expect(result).toEqual(['.env'])
+    })
+
+    it('returns all files when there are no patterns', () => {
+      const result = RsyncHelper.filterExcludedPaths(['a.txt'], [])
+      expect(result).toEqual(['a.txt'])
+    })
+  })
+
   describe('buildArgs', () => {
     it('should build correct args array with flags', () => {
       const args = rsyncHelper.buildArgs('/source', '/dest', {
@@ -1215,6 +1339,29 @@ describe('SymlinkHelper', () => {
     it('should create SymlinkHelper', () => {
       const helper = createSymlinkHelper(transaction)
       expect(helper).toBeInstanceOf(SymlinkHelper)
+    })
+  })
+
+  describe('createSymlinks with precomputed items', () => {
+    it('symlinks exactly the given items instead of re-matching patterns', async () => {
+      const sourceDir = path.join(testDir, 'source')
+      const targetDir = path.join(testDir, 'target')
+      await fs.ensureDir(sourceDir)
+      await fs.ensureDir(targetDir)
+      await fs.writeFile(path.join(sourceDir, '.env'), 'secret')
+      await fs.writeFile(path.join(sourceDir, 'CLAUDE.md'), 'tracked')
+
+      const result = await symlinkHelper.createSymlinks(
+        sourceDir,
+        targetDir,
+        { patterns: ['.env', 'CLAUDE.md'], relative: true, beforeRsync: true },
+        { items: ['.env'] }
+      )
+
+      expect(result.created).toBe(1)
+      const envStat = await fs.lstat(path.join(targetDir, '.env'))
+      expect(envStat.isSymbolicLink()).toBe(true)
+      expect(await fs.pathExists(path.join(targetDir, 'CLAUDE.md'))).toBe(false)
     })
   })
 

--- a/test/utils/git.test.ts
+++ b/test/utils/git.test.ts
@@ -568,8 +568,26 @@ branch refs/heads/main
       expect(mockWorktreeGit.raw).toHaveBeenCalledWith([
         'update-index',
         '--skip-worktree',
+        '--',
         'package.json',
         'pnpm-lock.yaml',
+      ])
+    })
+
+    it('should mark a tracked path that starts with a dash', async () => {
+      // Without a `--` separator before the path list, `-weird.txt` is parsed
+      // as a short-option cluster by git and update-index fails outright.
+      mockGitCalls({ trackedOutput: '-weird.txt\0' })
+
+      const result = await gitHelper.setSkipWorktree('/path/to/worktree', ['-weird.txt'])
+
+      expect(result.success).toBe(true)
+      expect(result.filesMarked).toBe(1)
+      expect(mockWorktreeGit.raw).toHaveBeenCalledWith([
+        'update-index',
+        '--skip-worktree',
+        '--',
+        '-weird.txt',
       ])
     })
 
@@ -596,6 +614,7 @@ branch refs/heads/main
       expect(mockWorktreeGit.raw).toHaveBeenCalledWith([
         'update-index',
         '--skip-worktree',
+        '--',
         'CLAUDE.md',
       ])
     })
@@ -623,6 +642,7 @@ branch refs/heads/main
       expect(mockWorktreeGit.raw).toHaveBeenCalledWith([
         'update-index',
         '--skip-worktree',
+        '--',
         '.claude/settings.json',
         '.claude/rules/beads.md',
       ])

--- a/test/utils/git.test.ts
+++ b/test/utils/git.test.ts
@@ -531,8 +531,24 @@ branch refs/heads/main
   })
 
   describe('setSkipWorktree', () => {
-    it('should mark files as skip-worktree', async () => {
-      mockWorktreeGit.raw.mockResolvedValue('')
+    /** Route the two-step flow: `ls-files` resolves tracked paths, `update-index` marks them */
+    const mockGitCalls = (options: {
+      trackedOutput: string
+      updateIndex?: (args: string[]) => Promise<string>
+    }) => {
+      mockWorktreeGit.raw.mockImplementation((args: string[]) => {
+        if (args[0] === 'ls-files') {
+          return Promise.resolve(options.trackedOutput)
+        }
+        if (args[0] === 'update-index') {
+          return options.updateIndex ? options.updateIndex(args) : Promise.resolve('')
+        }
+        return Promise.reject(new Error(`unexpected git call: ${args.join(' ')}`))
+      })
+    }
+
+    it('should mark tracked files as skip-worktree', async () => {
+      mockGitCalls({ trackedOutput: 'package.json\0pnpm-lock.yaml\0' })
 
       const result = await gitHelper.setSkipWorktree('/path/to/worktree', [
         'package.json',
@@ -542,6 +558,13 @@ branch refs/heads/main
       expect(result.success).toBe(true)
       expect(result.filesMarked).toBe(2)
       expect(result.error).toBeUndefined()
+      expect(mockWorktreeGit.raw).toHaveBeenCalledWith([
+        'ls-files',
+        '-z',
+        '--',
+        ':(literal)package.json',
+        ':(literal)pnpm-lock.yaml',
+      ])
       expect(mockWorktreeGit.raw).toHaveBeenCalledWith([
         'update-index',
         '--skip-worktree',
@@ -559,28 +582,160 @@ branch refs/heads/main
       expect(mockWorktreeGit.raw).not.toHaveBeenCalled()
     })
 
-    it('should handle errors gracefully', async () => {
-      mockWorktreeGit.raw.mockRejectedValue(new Error('fatal: Unable to mark file'))
+    it('should skip untracked paths and only mark tracked ones', async () => {
+      // .env is gitignored (not in index); CLAUDE.md is tracked.
+      // Previously the untracked path aborted the whole batch with
+      // "fatal: Unable to mark file .env" and NOTHING got marked.
+      mockGitCalls({ trackedOutput: 'CLAUDE.md\0' })
 
-      const result = await gitHelper.setSkipWorktree('/path/to/worktree', ['invalid-file'])
-
-      expect(result.success).toBe(false)
-      expect(result.error).toContain('Unable to mark file')
-      expect(result.filesMarked).toBe(0)
-    })
-
-    it('should handle single file', async () => {
-      mockWorktreeGit.raw.mockResolvedValue('')
-
-      const result = await gitHelper.setSkipWorktree('/path/to/worktree', ['node_modules'])
+      const result = await gitHelper.setSkipWorktree('/path/to/worktree', ['.env', 'CLAUDE.md'])
 
       expect(result.success).toBe(true)
       expect(result.filesMarked).toBe(1)
+      expect(result.error).toBeUndefined()
       expect(mockWorktreeGit.raw).toHaveBeenCalledWith([
         'update-index',
         '--skip-worktree',
-        'node_modules',
+        'CLAUDE.md',
       ])
+    })
+
+    it('should succeed with 0 marked when no requested path is tracked', async () => {
+      mockGitCalls({ trackedOutput: '' })
+
+      const result = await gitHelper.setSkipWorktree('/path/to/worktree', ['.env', '.vscode'])
+
+      expect(result.success).toBe(true)
+      expect(result.filesMarked).toBe(0)
+      expect(result.error).toBeUndefined()
+      expect(mockWorktreeGit.raw).not.toHaveBeenCalledWith(expect.arrayContaining(['update-index']))
+    })
+
+    it('should expand a symlinked directory to its tracked entries', async () => {
+      // update-index cannot mark a directory; ls-files expands `.claude` to
+      // the tracked files beneath it.
+      mockGitCalls({ trackedOutput: '.claude/settings.json\0.claude/rules/beads.md\0' })
+
+      const result = await gitHelper.setSkipWorktree('/path/to/worktree', ['.claude'])
+
+      expect(result.success).toBe(true)
+      expect(result.filesMarked).toBe(2)
+      expect(mockWorktreeGit.raw).toHaveBeenCalledWith([
+        'update-index',
+        '--skip-worktree',
+        '.claude/settings.json',
+        '.claude/rules/beads.md',
+      ])
+    })
+
+    it('should mark files independently when the batch fails', async () => {
+      mockGitCalls({
+        trackedOutput: 'a.txt\0b.txt\0',
+        updateIndex: (args) => {
+          // Batch call (both files) fails; per-file fallback fails only for b.txt
+          if (args.includes('b.txt')) {
+            return Promise.reject(new Error('fatal: Unable to mark file b.txt'))
+          }
+          return Promise.resolve('')
+        },
+      })
+
+      const result = await gitHelper.setSkipWorktree('/path/to/worktree', ['a.txt', 'b.txt'])
+
+      expect(result.success).toBe(false)
+      expect(result.filesMarked).toBe(1)
+      expect(result.error).toContain('b.txt')
+    })
+
+    it('should report failure when ls-files itself fails', async () => {
+      mockWorktreeGit.raw.mockRejectedValue(new Error('fatal: not a git repository'))
+
+      const result = await gitHelper.setSkipWorktree('/path/to/worktree', ['CLAUDE.md'])
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('not a git repository')
+      expect(result.filesMarked).toBe(0)
+    })
+  })
+
+  describe('listIgnoredFiles', () => {
+    it('should list gitignored untracked files (artifacts), not plain untracked ones', async () => {
+      mockWorktreeGit.raw.mockResolvedValue('.venv/bin/python\0node_modules/pkg/index.js\0.env\0')
+
+      const result = await gitHelper.listIgnoredFiles('/path/to/worktree')
+
+      expect(result).toEqual(['.venv/bin/python', 'node_modules/pkg/index.js', '.env'])
+      // --others --ignored --exclude-standard = only gitignored files, which is
+      // exactly the artifact set worktree setup wants to carry over. Plain
+      // untracked WIP files stay put so the new worktree's status stays clean.
+      expect(mockWorktreeGit.raw).toHaveBeenCalledWith([
+        'ls-files',
+        '--others',
+        '--ignored',
+        '--exclude-standard',
+        '-z',
+      ])
+    })
+
+    it('should return empty array when there are no ignored files', async () => {
+      mockWorktreeGit.raw.mockResolvedValue('')
+
+      const result = await gitHelper.listIgnoredFiles('/path/to/worktree')
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('filterTrackedPaths', () => {
+    it('should return only paths that are tracked (files or dirs with tracked entries)', async () => {
+      // .claude is a directory containing tracked files; CLAUDE.md is a tracked
+      // file; .env and .vscode are untracked/ignored
+      mockWorktreeGit.raw.mockResolvedValue('.claude/settings.json\0CLAUDE.md\0')
+
+      const result = await gitHelper.filterTrackedPaths('/path/to/worktree', [
+        '.claude',
+        'CLAUDE.md',
+        '.env',
+        '.vscode',
+      ])
+
+      expect(result).toEqual(['.claude', 'CLAUDE.md'])
+      expect(mockWorktreeGit.raw).toHaveBeenCalledWith([
+        'ls-files',
+        '-z',
+        '--',
+        ':(literal).claude',
+        ':(literal)CLAUDE.md',
+        ':(literal).env',
+        ':(literal).vscode',
+      ])
+    })
+
+    it('should return empty array for empty input without calling git', async () => {
+      const result = await gitHelper.filterTrackedPaths('/path/to/worktree', [])
+
+      expect(result).toEqual([])
+      expect(mockWorktreeGit.raw).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getDirtyPaths', () => {
+    it('should return paths from git status', async () => {
+      mockWorktreeGit.status.mockResolvedValue({
+        files: [{ path: 'CLAUDE.md' }, { path: 'src/new-file.ts' }],
+      })
+
+      const result = await gitHelper.getDirtyPaths('/path/to/worktree')
+
+      expect(result).toEqual(['CLAUDE.md', 'src/new-file.ts'])
+    })
+
+    it('should return empty array for a clean worktree', async () => {
+      mockWorktreeGit.status.mockResolvedValue({ files: [] })
+
+      const result = await gitHelper.getDirtyPaths('/path/to/worktree')
+
+      expect(result).toEqual([])
     })
   })
 

--- a/test/utils/worktreeSetup.test.ts
+++ b/test/utils/worktreeSetup.test.ts
@@ -77,6 +77,12 @@ describe('WorktreeSetupOrchestrator', () => {
       getWorktreeCommit: vi.fn().mockResolvedValue('abc123def456'),
       removeWorktree: vi.fn().mockResolvedValue(undefined),
       setSkipWorktree: vi.fn().mockResolvedValue({ success: true, filesMarked: 0 }),
+      // No symlink pattern is git-tracked by default
+      filterTrackedPaths: vi.fn().mockResolvedValue([]),
+      listIgnoredFiles: vi
+        .fn()
+        .mockResolvedValue(['.venv/lib/pkg.py', 'node_modules/dep/index.js']),
+      getDirtyPaths: vi.fn().mockResolvedValue([]),
     } as any
 
     // Create mock config
@@ -220,6 +226,7 @@ describe('WorktreeSetupOrchestrator', () => {
         {
           replaceExisting: true,
           skipConflicts: true,
+          items: ['package.json', 'pnpm-lock.yaml'],
         }
       )
       expect(result.symlinkResult).toBeDefined()
@@ -307,7 +314,53 @@ describe('WorktreeSetupOrchestrator', () => {
       expect(result.rsyncResult).toBeUndefined()
     })
 
-    it('should skip rsync when source and target commits differ', async () => {
+    it('should sync only ignored files by default (onlyUntracked)', async () => {
+      const result = await orchestrator.setupNewWorktree('/repo/feature')
+
+      expect(mockGitHelper.listIgnoredFiles).toHaveBeenCalledWith('/repo/main')
+      expect(mockRsyncHelper.rsync).toHaveBeenCalledWith(
+        '/repo/main',
+        '/repo/feature',
+        mockConfig.rsync,
+        expect.objectContaining({
+          filesFrom: ['.venv/lib/pkg.py', 'node_modules/dep/index.js'],
+        })
+      )
+      expect(result.rsyncResult).toBeDefined()
+    })
+
+    it('should rsync in onlyUntracked mode even when commits differ', async () => {
+      // Existing-branch worktrees are on a different commit than the source.
+      // Only ignored artifacts are synced, so crossing commits is safe - this
+      // is the case where the old commit guard silently disabled artifact sync.
+      vi.mocked(mockGitHelper.getWorktreeCommit)
+        .mockResolvedValueOnce('source1234567890')
+        .mockResolvedValueOnce('target1234567890')
+
+      const result = await orchestrator.setupNewWorktree('/repo/feature')
+
+      expect(mockRsyncHelper.rsync).toHaveBeenCalledWith(
+        '/repo/main',
+        '/repo/feature',
+        mockConfig.rsync,
+        expect.objectContaining({
+          filesFrom: ['.venv/lib/pkg.py', 'node_modules/dep/index.js'],
+        })
+      )
+      expect(result.rsyncResult).toBeDefined()
+    })
+
+    it('should skip rsync in onlyUntracked mode when there are no ignored files', async () => {
+      vi.mocked(mockGitHelper.listIgnoredFiles).mockResolvedValue([])
+
+      const result = await orchestrator.setupNewWorktree('/repo/feature')
+
+      expect(mockRsyncHelper.rsync).not.toHaveBeenCalled()
+      expect(result.rsyncResult).toBeUndefined()
+    })
+
+    it('should skip rsync when source and target commits differ (full mirror mode)', async () => {
+      mockConfig.rsync.onlyUntracked = false
       vi.mocked(mockGitHelper.getWorktreeCommit)
         .mockResolvedValueOnce('source1234567890')
         .mockResolvedValueOnce('target1234567890')
@@ -320,6 +373,23 @@ describe('WorktreeSetupOrchestrator', () => {
       expect(result.warnings).toContain(
         'Skipped rsync because source worktree (source1) differs from target worktree (target1). This prevents tracked files from being copied across different commits.'
       )
+    })
+
+    it('should mirror the full tree in full mirror mode when commits match', async () => {
+      mockConfig.rsync.onlyUntracked = false
+
+      const result = await orchestrator.setupNewWorktree('/repo/feature')
+
+      expect(mockGitHelper.listIgnoredFiles).not.toHaveBeenCalled()
+      expect(mockRsyncHelper.rsync).toHaveBeenCalledWith(
+        '/repo/main',
+        '/repo/feature',
+        mockConfig.rsync,
+        expect.objectContaining({
+          filesFrom: undefined,
+        })
+      )
+      expect(result.rsyncResult).toBeDefined()
     })
 
     it('should skip rsync when config.rsync.enabled=false', async () => {
@@ -416,6 +486,7 @@ describe('WorktreeSetupOrchestrator', () => {
         {
           replaceExisting: true,
           skipConflicts: true,
+          items: ['package.json', 'pnpm-lock.yaml'],
         }
       )
       expect(result.symlinkResult).toBeDefined()
@@ -445,6 +516,116 @@ describe('WorktreeSetupOrchestrator', () => {
       const result = await orchestrator.setupNewWorktree('/repo/feature')
 
       expect(result.warnings).toContain('Could not create 1 symlink(s) due to conflicts')
+    })
+  })
+
+  // ==========================================================================
+  // Tracked-path symlink guard
+  // ==========================================================================
+
+  describe('tracked-path symlink guard', () => {
+    it('symlinks tracked patterns without warnings by default (allowTracked)', async () => {
+      vi.mocked(mockSymlinkHelper.matchPatterns).mockResolvedValue(['.claude', '.env'])
+
+      const result = await orchestrator.setupNewWorktree('/repo/feature')
+
+      expect(mockSymlinkHelper.createSymlinks).toHaveBeenCalledWith(
+        '/repo/main',
+        '/repo/feature',
+        mockConfig.symlink,
+        expect.objectContaining({ items: ['.claude', '.env'] })
+      )
+      // Skip-worktree marking + clean-tree check cover tracked symlinks, so
+      // the default mode should not warn
+      expect(result.warnings.some((w) => w.includes('git-tracked'))).toBe(false)
+      // No tracked-path lookup needed when everything is allowed
+      expect(mockGitHelper.filterTrackedPaths).not.toHaveBeenCalled()
+    })
+
+    it('skips tracked patterns with a warning when allowTracked is false', async () => {
+      mockConfig.symlink.allowTracked = false
+      vi.mocked(mockSymlinkHelper.matchPatterns).mockResolvedValue(['.claude', 'CLAUDE.md', '.env'])
+      vi.mocked(mockGitHelper.filterTrackedPaths).mockResolvedValue(['.claude', 'CLAUDE.md'])
+
+      const result = await orchestrator.setupNewWorktree('/repo/feature')
+
+      expect(mockSymlinkHelper.createSymlinks).toHaveBeenCalledWith(
+        '/repo/main',
+        '/repo/feature',
+        mockConfig.symlink,
+        expect.objectContaining({ items: ['.env'] })
+      )
+      expect(
+        result.warnings.some((w) => w.includes('Skipped symlinking git-tracked path(s)'))
+      ).toBe(true)
+      expect(result.warnings.some((w) => w.includes('.claude, CLAUDE.md'))).toBe(true)
+    })
+
+    it('does not remove checked-out files for tracked patterns that were skipped', async () => {
+      mockConfig.symlink.allowTracked = false
+      vi.mocked(mockSymlinkHelper.matchPatterns).mockResolvedValue(['CLAUDE.md', '.env'])
+      vi.mocked(mockGitHelper.filterTrackedPaths).mockResolvedValue(['CLAUDE.md'])
+
+      await orchestrator.setupNewWorktree('/repo/feature')
+
+      const removedPaths = vi.mocked(mockRemove).mock.calls.map((call) => call[0])
+      expect(removedPaths).not.toContain('/repo/feature/CLAUDE.md')
+      expect(removedPaths).toContain('/repo/feature/.env')
+    })
+  })
+
+  // ==========================================================================
+  // Clean-tree invariant
+  // ==========================================================================
+
+  describe('clean-tree invariant', () => {
+    it('reports cleanTree=true when git status is empty after setup', async () => {
+      const result = await orchestrator.setupNewWorktree('/repo/feature')
+
+      expect(mockGitHelper.getDirtyPaths).toHaveBeenCalledWith('/repo/feature')
+      expect(result.cleanTree).toBe(true)
+    })
+
+    it('reports cleanTree=false with a warning listing dirty paths', async () => {
+      vi.mocked(mockGitHelper.getDirtyPaths).mockResolvedValue([
+        'CLAUDE.md',
+        '.claude/settings.json',
+      ])
+
+      const result = await orchestrator.setupNewWorktree('/repo/feature')
+
+      expect(result.cleanTree).toBe(false)
+      expect(
+        result.warnings.some(
+          (w) =>
+            w.includes('Worktree is not clean after setup') &&
+            w.includes('CLAUDE.md') &&
+            w.includes('.claude/settings.json')
+        )
+      ).toBe(true)
+    })
+
+    it('leaves cleanTree undefined when the status check fails', async () => {
+      vi.mocked(mockGitHelper.getDirtyPaths).mockRejectedValue(new Error('git status failed'))
+
+      const result = await orchestrator.setupNewWorktree('/repo/feature')
+
+      expect(result.success).toBe(true)
+      expect(result.cleanTree).toBeUndefined()
+    })
+
+    it('tolerates the symlinks pando itself created', async () => {
+      // A symlink over a tracked directory shows as untracked (`?? .claude`)
+      // even when its files are skip-worktree'd - that is intentional state,
+      // not pollution
+      mockConfig.symlink.allowTracked = true
+      vi.mocked(mockSymlinkHelper.matchPatterns).mockResolvedValue(['.claude', '.env'])
+      vi.mocked(mockGitHelper.filterTrackedPaths).mockResolvedValue(['.claude'])
+      vi.mocked(mockGitHelper.getDirtyPaths).mockResolvedValue(['.claude', '.env'])
+
+      const result = await orchestrator.setupNewWorktree('/repo/feature')
+
+      expect(result.cleanTree).toBe(true)
     })
   })
 

--- a/test/utils/worktreeSetup.test.ts
+++ b/test/utils/worktreeSetup.test.ts
@@ -209,6 +209,22 @@ describe('WorktreeSetupOrchestrator', () => {
         path: '/repo/feature',
       })
     })
+
+    it('creates the checkpoint before symlink planning, so a planning failure can still roll back the worktree', async () => {
+      // If matchPatterns/filterTrackedPaths throws before the checkpoint is
+      // created, rollback() has no 'worktree' checkpoint to remove the
+      // already-created git worktree - it would be silently orphaned. Asserting
+      // createCheckpoint still ran proves the ordering survives a planning
+      // failure (real FileOperationTransaction.rollback() behavior is covered
+      // separately in the "regression test" describe block below).
+      vi.mocked(mockSymlinkHelper.matchPatterns).mockRejectedValue(new Error('glob explosion'))
+
+      await expect(orchestrator.setupNewWorktree('/repo/feature')).rejects.toThrow(SetupError)
+
+      expect(mockTransaction.createCheckpoint).toHaveBeenCalledWith('worktree', {
+        path: '/repo/feature',
+      })
+    })
   })
 
   // ==========================================================================
@@ -396,6 +412,15 @@ describe('WorktreeSetupOrchestrator', () => {
       mockConfig.rsync.enabled = false
 
       const result = await orchestrator.setupNewWorktree('/repo/feature')
+
+      expect(mockRsyncHelper.rsync).not.toHaveBeenCalled()
+      expect(result.rsyncResult).toBeUndefined()
+    })
+
+    it('should skip rsync when rsyncOverride.enabled=false, even if base config enables it', async () => {
+      const options: SetupOptions = { rsyncOverride: { enabled: false } }
+
+      const result = await orchestrator.setupNewWorktree('/repo/feature', options)
 
       expect(mockRsyncHelper.rsync).not.toHaveBeenCalled()
       expect(result.rsyncResult).toBeUndefined()


### PR DESCRIPTION
## Summary

Fixes a bug report where a single `pando add` for an existing branch left the new worktree dirty (deleted/type-changed tracked files, modified tracked files, and untracked spillover from the source branch).

- **skip-worktree batch abort**: `setSkipWorktree` used to pass every symlinked path to one `git update-index --skip-worktree` call, which dies on any path not in the index (e.g. a gitignored `.env` symlink) and aborted the whole batch — so tracked symlinks like `CLAUDE.md`/`.claude/` were never hidden from `git status`. Now filters to git-tracked paths first, expands symlinked directories to their tracked entries (a directory itself can't be marked), and marks independently with a per-file fallback so one bad path can't hide the rest.
- **rsync tracked-file clobbering**: rsync could copy the source branch's tracked tree onto a different target branch's checkout. New default `rsync.onlyUntracked = true` syncs only files git ignores in the source worktree (build artifacts, caches) via `--files-from`, so tracked content always comes from the target's own checkout — this also means artifact sync now works for existing branches on a different commit than the source, which the old commit-mismatch guard used to silently skip entirely. `rsync.onlyUntracked = false` restores the legacy full-tree mirror behind that same commit guard.
- **tracked-symlink guard**: new `symlink.allowTracked` config (default `true`, hidden via skip-worktree) with a strict opt-out (`false`) that skips symlink patterns matching git-tracked paths and warns instead.
- **clean-tree invariant**: after setup, `pando add` runs `git status` in the new worktree and warns with the offending paths if anything unexpected shows up; `--json` output includes `setup.cleanTree` for automation.

## Test plan

- [x] New unit tests for `GitHelper.setSkipWorktree`/`filterTrackedPaths`/`listIgnoredFiles`/`getDirtyPaths` (`test/utils/git.test.ts`)
- [x] New unit tests for `RsyncHelper` `--files-from` support and `filterExcludedPaths` (`test/utils/fileOps.test.ts`)
- [x] Updated `WorktreeSetupOrchestrator` unit tests for the symlink plan, untracked-only rsync, tracked-symlink guard, and clean-tree check (`test/utils/worktreeSetup.test.ts`)
- [x] New integration suite using real git + rsync (`test/integration/worktreeSetup.integration.test.ts`), covering: the bug report's exact repro, tracked-file protection across branches, source-worktree integrity, and the strict `allowTracked=false` mode
- [x] Updated Docker e2e fixtures/assertions for the new defaults (`test/e2e/commands/add.e2e.test.ts`) — not run locally (Docker unavailable in this environment); needs a CI run
- [x] `pnpm validate` (format, lint, typecheck, full unit suite — 672 tests) passes
- [x] Manual CLI smoke test reproducing the original report's config shape (mixed tracked/ignored symlink patterns, existing branch on a different commit) confirms `git status --porcelain` is empty after `pando add`