### PR TITLE
chore: drop Node 18 support, require Node >= 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - name: Checkout code
@@ -157,7 +157,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20.x
+          # Node 22: testcontainers 12 pulls undici 8, which needs Node >= 20.18
+          node-version: 22.x
           cache: pnpm
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Minimum supported Node.js is now 20** (was 18). Node 18 reached end-of-life
+  in April 2025; the `engines` field, CI test matrix, and Docker E2E runner have
+  been updated accordingly. This unblocks dependencies that require Node >= 20.
 - Default rsync flags are now `["--archive"]`. `.git` is always excluded
   automatically by Pando (in `fileOps.buildArgs`) and must no longer be listed
   in the flags.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ Git worktrees, built on [oclif](https://oclif.io) and
 ## Prerequisites
 
 - **Node.js 20** — the project pins Node 20 via the `.node-version` file. The
-  published package supports Node >= 18, and CI also runs the test matrix on
-  Node 18, 20, and 22, but Node 20 is the recommended development version.
+  published package supports Node >= 20, and CI also runs the test matrix on
+  Node 20 and 22, but Node 20 is the recommended development version.
 - **pnpm** — the package manager for this repo (`packageManager` is pinned in
   `package.json`). Install with `npm install -g pnpm` or via
   [corepack](https://nodejs.org/api/corepack.html).

--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ pando/
 
 ## Requirements
 
-- Node.js >= 18.0.0 (development targets Node 20, pinned in `.node-version`)
+- Node.js >= 20.0.0 (development targets Node 20, pinned in `.node-version`)
 - Git >= 2.5.0 (for worktree support)
 
 ## Troubleshooting

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "automation"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Node 18 reached end-of-life in April 2025. This raises the Node floor so the project can adopt dependencies that require Node >= 20.

## Changes
- `package.json`: `engines.node` `>=18.0.0` → `>=20.0.0`
- CI validate matrix: `[18.x, 20.x, 22.x]` → `[20.x, 22.x]`
- Docker E2E runner: Node `20.x` → `22.x` (testcontainers 12 pulls undici 8, which requires Node >= 20.18)
- README + CONTRIBUTING updated to reflect Node >= 20
- CHANGELOG entry under Unreleased → Changed

## Why
Unblocks the open Dependabot upgrades that require Node >= 20:
- #52 ora 8 → 9
- #50 globby 14 → 16
- #48 testcontainers 10 → 12 (undici 8 needs the Node 22 E2E runner)

Node 18 has been EOL for 15+ months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)